### PR TITLE
Add tasks for code analysis and running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,12 @@ jobs:
             Parallel_Computing_Toolbox
             Optimization_Toolbox
             Econometrics_Toolbox
+
       # Runs a set of commands using the runners shell
-      - name: Check MATLAB Install
-        uses: matlab-actions/run-command@v1
+      - name: Run MATLAB Tests
+        uses: matlab-actions/run-build@v1
         with:
-          command: "run runAllMyTestsFS.m" 
+          tasks: test
           
 
           

--- a/buildfile.m
+++ b/buildfile.m
@@ -9,29 +9,18 @@ plan("toolbox").Dependencies = "doc";
 plan.DefaultTasks = "toolbox";
 end
 
-function docTask(~)
+function docTask(context)
 % This task builds the doc search DB for the current version of MATLAB - the
 % expected output will be in the folder ./helpfiles/pointersHTML
-cleanup = iCdWithRevert(fullfile(iGetRootFolder, "utilities_help", "build")); %#ok<NASGU>
+cleanup = iCdWithRevert(fullfile(context.Plan.RootFolder, "utilities_help", "build")); %#ok<NASGU>
 buildDocSearchForToolbox
 end
 
-function toolboxTask(~)
+function toolboxTask(context)
 % This task packages the toolbox MLTBX file - the expected output will be
 % in the ./bin/ folder (defined in the createMLTBX file)
-cleanup = iCdWithRevert(fullfile(iGetRootFolder, "utilities_help", "build")); %#ok<NASGU>
+cleanup = iCdWithRevert(fullfile(context.Plan.RootFolder, "utilities_help", "build")); %#ok<NASGU>
 createMLTBX
-end
-
-function root = iGetRootFolder()
-% buildfile.m is always in the root of the toolbox - so use this definition
-% to get the root of the toolbox from the location of buildfile.m
-persistent THE_ROOT
-if isempty(THE_ROOT)
-    thisFile = mfilename("fullpath");
-    THE_ROOT = fileparts(thisFile);
-end
-root = THE_ROOT;
 end
 
 function cleanup = iCdWithRevert(folder)

--- a/buildfile.m
+++ b/buildfile.m
@@ -9,7 +9,7 @@ plan("toolbox").Dependencies = "doc";
 plan.DefaultTasks = "toolbox";
 end
 
-function lintTask(~)
+function checkTask(~)
 issues = codeIssues;
 errors = issues.Issues(issues.Issues.Severity == "error", ...
     ["Location" "Severity" "Description"]);

--- a/buildfile.m
+++ b/buildfile.m
@@ -9,6 +9,22 @@ plan("toolbox").Dependencies = "doc";
 plan.DefaultTasks = "toolbox";
 end
 
+function lintTask(~)
+issues = codeIssues;
+errors = issues.Issues(issues.Issues.Severity == "error", ...
+    ["Location" "Severity" "Description"]);
+assert(isempty(errors),formattedDisplayText(errors))
+end
+
+function testTask(~, cat2test, options)
+arguments
+    ~
+    cat2test char = getenv('CATEGORY_TO_TEST')
+    options.Performance (1,1) logical = false
+end
+runAllMyTestsFS(cat2test, Performance=options.Performance)
+end
+
 function docTask(context)
 % This task builds the doc search DB for the current version of MATLAB - the
 % expected output will be in the folder ./helpfiles/pointersHTML

--- a/runAllMyTestsFS.m
+++ b/runAllMyTestsFS.m
@@ -1,4 +1,8 @@
-
+function runAllMyTestsFS(cat2test, options)
+arguments
+    cat2test char = getenv('CATEGORY_TO_TEST')
+    options.Performance (1,1) logical = false
+end
 %% Load necessary elements for performance test
 % load OUT
 run addFSDA2path
@@ -6,6 +10,8 @@ FileName='addFSDA2path';
 FullPath=which(FileName);
 %Navigate to the main folder of FSDA
 FSDAroot=fileparts(FullPath);
+cdir = pwd;
+cleanup = onCleanup(@() cd(cdir));
 cd(FSDAroot)
 % Specify subfolders of main folders for which contents file has to be
 % created
@@ -14,7 +20,7 @@ InclDir={'graphics' 'regression' 'multivariate' 'clustering' 'combinatorial' ...
 ExclDir={'privateFS'  'datasets'};
 % Create list of folders which must have the personalized contents file
 list = findDir(FSDAroot,'InclDir',InclDir,'ExclDir',ExclDir);
-% Crete personalized contents file for main folder of FSDA
+% Create personalized contents file for main folder of FSDA
 % and required subfolders.
 force=false;
 warning('off')
@@ -25,15 +31,12 @@ FilesIncludedAll= FilesIncluded;
 warning('on')
 disp(filesWithProblems)
 
-%% Category to test
-cat2test=getenv('CATEGORY_TO_TEST');
-disp('---------------')
-disp('Test for category:')
-disp(cat2test)
-disp('---------------')
-
-% VIS GUI MULT CLUS REG UTI
-if strcmp(cat2test,'graphics')
+if isempty(cat2test)
+    FilesIncluded=FilesIncludedAll;
+    boo = true(length(FilesIncluded), 1);
+    cat2test = 'all';
+elseif strcmp(cat2test,'graphics')
+    % VIS GUI MULT CLUS REG UTI
     str=regexp(FilesIncluded(:,8),'VIS*');
     boo1=~cellfun(@isempty,str);
     str=regexp(FilesIncluded(:,8),'GUI');
@@ -123,10 +126,13 @@ elseif strcmp(cat2test,'utilities')
 else
     error('FSDA:runTests:WrgCLS','Wrong class')
 end
-
+    
 OUT=OUT(boo,:);
 FilesIncluded=FilesIncluded(boo,:);
 
+disp('---------------')
+disp(['Running ' cat2test ' tests'])
+disp('---------------')
 
 ij=1;
 nfiles=length(OUT);
@@ -147,8 +153,9 @@ cd(FSDAroot)
 
 % Use perf = true if for each example you want run runperf.m
 % Use perf = true if for each example you want run runtests.m
-perf = false;
+perf = options.Performance;
 testpath= ['tests-' cat2test];
+disp(testpath)
 mkdir(testpath);
 
 

--- a/utilities_help/build/README.md
+++ b/utilities_help/build/README.md
@@ -17,7 +17,7 @@ To trigger a completely new release of the toolbox on `github` using the
 ```
 2. In that clean repo create the tag for the new release of the FSDA toolbox
 ```
-    git tag 8.7.1.0
+    git tag -a -m "Release comment" 8.7.1.0
 ```
 3. Push the new tags to github
 ```


### PR DESCRIPTION
We don't have to merge this. I just wanted to submit it as a PR so it's easier to view and I didn't have to email code.

This is one way that they could get similar behavior to CI locally through buildtool. Currently they can only filter tests through environment variables. This seems a little annoying when testing locally so I updated it so you can also filter using task arguments.

Running `buildtool test` will run all their tests. Running `buildtool test("regression")` will run only the regression tests. Running `buildtool test(Performance=true)` will run all tests including their performance tests (off by default).

I updated `ci.yml` to run tests using the run-build action to make sure it was behaving the same as before. The "check" task will fail if added to CI currently because they have a handful of "error" severity findings, but it could be nice in the pipeline as well.